### PR TITLE
Remove closing PHP tags

### DIFF
--- a/alaska-adventure-theme/404.php
+++ b/alaska-adventure-theme/404.php
@@ -206,5 +206,4 @@ get_header(); ?>
     }
 }
 </style>
-
-<?php get_footer(); ?> 
+<?php get_footer();

--- a/alaska-adventure-theme/archive_travel_day.php
+++ b/alaska-adventure-theme/archive_travel_day.php
@@ -351,5 +351,4 @@ get_header(); ?>
     }
 }
 </style>
-
-<?php get_footer(); ?>
+<?php get_footer();

--- a/alaska-adventure-theme/functions.php
+++ b/alaska-adventure-theme/functions.php
@@ -1237,5 +1237,3 @@ function alaska_travel_filter_photos() {
 }
 add_action('wp_ajax_alaska_travel_filter_photos', 'alaska_travel_filter_photos');
 add_action('wp_ajax_nopriv_alaska_travel_filter_photos', 'alaska_travel_filter_photos');
-
-?>

--- a/alaska-adventure-theme/index.php
+++ b/alaska-adventure-theme/index.php
@@ -379,5 +379,4 @@ get_header(); ?>
     }
 }
 </style>
-
-<?php get_footer(); ?>
+<?php get_footer();

--- a/alaska-adventure-theme/page_photos.php
+++ b/alaska-adventure-theme/page_photos.php
@@ -505,5 +505,4 @@ jQuery(document).ready(function($) {
     });
 });
 </script>
-
-<?php get_footer(); ?>
+<?php get_footer();

--- a/alaska-adventure-theme/search.php
+++ b/alaska-adventure-theme/search.php
@@ -316,5 +316,4 @@ get_header(); ?>
     }
 }
 </style>
-
-<?php get_footer(); ?> 
+<?php get_footer();

--- a/alaska-adventure-theme/single_travel_day.php
+++ b/alaska-adventure-theme/single_travel_day.php
@@ -238,5 +238,4 @@ get_header(); ?>
         <?php get_sidebar(); ?>
     </aside>
 </main>
-
-<?php get_footer(); ?>
+<?php get_footer();

--- a/alaska-adventure-theme/travel_days_page.php
+++ b/alaska-adventure-theme/travel_days_page.php
@@ -104,5 +104,4 @@ get_header(); ?>
         <?php get_sidebar(); ?>
     </aside>
 </main>
-
-<?php get_footer(); ?>
+<?php get_footer();

--- a/alaska_travel_plugin/alaska_travel_plugin.php
+++ b/alaska_travel_plugin/alaska_travel_plugin.php
@@ -651,4 +651,3 @@ function alaska_travel_post_states($post_states, $post) {
     return $post_states;
 }
 add_filter('display_post_states', 'alaska_travel_post_states', 10, 2);
-?>


### PR DESCRIPTION
## Summary
- delete closing `?>` tags at the end of PHP files
- ensure each file ends with a newline and no trailing whitespace

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e53f37ca8832d9b7789efd3b84790